### PR TITLE
Fix META.yml for Text::Transliterator::Unaccent

### DIFF
--- a/META.json
+++ b/META.json
@@ -1,0 +1,55 @@
+{
+   "abstract" : "Wrapper around Perl tr/../../ operator",
+   "author" : [
+      "Laurent Dami <lau.....da..@justice.ge.ch>"
+   ],
+   "dynamic_config" : 1,
+   "generated_by" : "Module::Build version 0.4224",
+   "license" : [
+      "perl_5"
+   ],
+   "meta-spec" : {
+      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
+      "version" : "2"
+   },
+   "name" : "Text-Transliterator",
+   "prereqs" : {
+      "build" : {
+         "requires" : {
+            "Test::More" : "0"
+         }
+      },
+      "configure" : {
+         "requires" : {
+            "Module::Build" : "0.42"
+         }
+      },
+      "runtime" : {
+         "requires" : {
+            "Unicode::Normalize" : "0",
+            "Unicode::UCD" : "0"
+         }
+      }
+   },
+   "provides" : {
+      "Text::Transliterator" : {
+         "file" : "lib/Text/Transliterator.pm",
+         "version" : "1.02"
+      },
+      "Text::Transliterator::Unaccent" : {
+         "file" : "lib/Text/Transliterator/Unaccent.pm",
+         "version" : "1.02"
+      }
+   },
+   "release_status" : "stable",
+   "resources" : {
+      "license" : [
+         "http://dev.perl.org/licenses/"
+      ],
+      "repository" : {
+         "url" : "https://github.com/damil/Text-Transliterator"
+      }
+   },
+   "version" : "1.02",
+   "x_serialization_backend" : "JSON::PP version 2.27400_02"
+}

--- a/META.yml
+++ b/META.yml
@@ -1,29 +1,30 @@
 ---
-abstract: Wrapper around Perl tr/../../ operator
+abstract: 'Wrapper around Perl tr/../../ operator'
 author:
   - 'Laurent Dami <lau.....da..@justice.ge.ch>'
 build_requires:
-  Test::More: 0
+  Test::More: '0'
 configure_requires:
-  Module::Build: 0.40
+  Module::Build: '0.42'
 dynamic_config: 1
-generated_by: 'Module::Build version 0.4003, CPAN::Meta::Converter version 2.120921'
+generated_by: 'Module::Build version 0.4224, CPAN::Meta::Converter version 2.150010'
 license: perl
 meta-spec:
   url: http://module-build.sourceforge.net/META-spec-v1.4.html
-  version: 1.4
+  version: '1.4'
 name: Text-Transliterator
 provides:
   Text::Transliterator:
     file: lib/Text/Transliterator.pm
-    version: 1.01
+    version: '1.02'
   Text::Transliterator::Unaccent:
     file: lib/Text/Transliterator/Unaccent.pm
-    version: 1.00
+    version: '1.02'
 requires:
-  Unicode::Normalize: 0
-  Unicode::UCD: 0
+  Unicode::Normalize: '0'
+  Unicode::UCD: '0'
 resources:
   license: http://dev.perl.org/licenses/
   repository: https://github.com/damil/Text-Transliterator
-version: 1.01
+version: '1.02'
+x_serialization_backend: 'CPAN::Meta::YAML version 0.018'


### PR DESCRIPTION
Update META.yml as well as add META.json in order for
Text::Transliterator::Unaccent to be indexed correctly by CPAN tooling.

This also needs the author and other contributors to also update their
Module::Build installation to latest version.

Fixes #2, and possibly #1 as well.